### PR TITLE
Add supplementary groups for `RUN_USER`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,6 @@ UID: the uid of the user
 GID: the gid of the user
 RUN_USER: the username of the user
 RUN_GROUP: the group of the user
-OTHER_GID: a supplementary gid which the user is also a member of
-OTHER_RUN_GROUP: a supplementary group which the user is also a member of
+OTHER_GID: list of supplementary gid (comma separated) which the user is also a member of
+OTHER_RUN_GROUP: list of supplementary group (comma separated) which the user is also a member of. The order must match the order used for OTHER_GID.
 ```

--- a/README.md
+++ b/README.md
@@ -54,4 +54,6 @@ UID: the uid of the user
 GID: the gid of the user
 RUN_USER: the username of the user
 RUN_GROUP: the group of the user
+OTHER_GID: a supplementary gid which the user is also a member of
+OTHER_RUN_GROUP: a supplementary group which the user is also a member of
 ```

--- a/scripts/pre-launch.d/08script_user
+++ b/scripts/pre-launch.d/08script_user
@@ -3,10 +3,9 @@ if [ -n "$GID" ]; then
 	getent group $RUN_GROUP &> /dev/null || groupadd $GIDoption $RUN_GROUP
 fi
 
-$otherGIDoption=""
 if [ -n "$OTHER_GID" ]; then
-    $otherGIDoption="--groups $OTHER_GID"
-	getent group $OTHER_RUN_GROUP &> /dev/null || groupadd --gid $OTHER_GID $OTHER_RUN_GROUP
+    otherGIDoption="--groups $OTHER_GID"
+    getent group $OTHER_RUN_GROUP &> /dev/null || groupadd --gid $OTHER_GID $OTHER_RUN_GROUP
 fi
 
 if [ -n "$UID" ]; then

--- a/scripts/pre-launch.d/08script_user
+++ b/scripts/pre-launch.d/08script_user
@@ -9,8 +9,8 @@ if [ -n "$OTHER_GID" ]; then
     length=${#OTHER_GID_ARRAY[@]}
     GROUPS="--groups "
     for (( i=0; i<$length; i++ )); do
-        getent group $OTHER_RUN_GROUP_ARRAY[i] &> /dev/null || groupadd --gid $OTHER_GID_ARRAY[i] $OTHER_RUN_GROUP_ARRAY[i]
-        GROUPS+="$OTHER_GID_ARRAY[i],"
+        getent group ${OTHER_RUN_GROUP_ARRAY[i]} &> /dev/null || groupadd --gid ${OTHER_GID_ARRAY[i]} ${OTHER_RUN_GROUP_ARRAY[i]}
+        GROUPS+="${OTHER_GID_ARRAY[i]},"
     done
     otherGIDoption=${GROUPS::-1}
 fi

--- a/scripts/pre-launch.d/08script_user
+++ b/scripts/pre-launch.d/08script_user
@@ -4,8 +4,15 @@ if [ -n "$GID" ]; then
 fi
 
 if [ -n "$OTHER_GID" ]; then
-    otherGIDoption="--groups $OTHER_GID"
-    getent group $OTHER_RUN_GROUP &> /dev/null || groupadd --gid $OTHER_GID $OTHER_RUN_GROUP
+    IFS=',' read -ra OTHER_GID_ARRAY  <<< "$OTHER_GID"
+    IFS=',' read -ra OTHER_RUN_GROUP_ARRAY  <<< "$OTHER_RUN_GROUP"
+    length=${#OTHER_GID_ARRAY[@]}
+    GROUPS="--groups "
+    for (( i=0; i<$length; i++ )); do
+        getent group $OTHER_RUN_GROUP_ARRAY[i] &> /dev/null || groupadd --gid $OTHER_GID_ARRAY[i] $OTHER_RUN_GROUP_ARRAY[i]
+        GROUPS+="$OTHER_GID_ARRAY[i],"
+    done
+    otherGIDoption=${GROUPS::-1}
 fi
 
 if [ -n "$UID" ]; then

--- a/scripts/pre-launch.d/08script_user
+++ b/scripts/pre-launch.d/08script_user
@@ -3,7 +3,13 @@ if [ -n "$GID" ]; then
 	getent group $RUN_GROUP &> /dev/null || groupadd $GIDoption $RUN_GROUP
 fi
 
+$otherGIDoption=""
+if [ -n "$OTHER_GID" ]; then
+    $otherGIDoption="--groups $OTHER_GID"
+	getent group $OTHER_RUN_GROUP &> /dev/null || groupadd --gid $OTHER_GID $OTHER_RUN_GROUP
+fi
+
 if [ -n "$UID" ]; then
 	UIDoption="--uid $UID"
-	id -u $RUN_USER &> /dev/null || useradd -d /tmp/$RUN_USER --create-home --no-user-group $UIDoption $GIDoption $RUN_USER
+	id -u $RUN_USER &> /dev/null || useradd -d /tmp/$RUN_USER --create-home --no-user-group $UIDoption $GIDoption $otherGIDoption $RUN_USER
 fi

--- a/scripts/pre-launch.d/08script_user
+++ b/scripts/pre-launch.d/08script_user
@@ -7,12 +7,12 @@ if [ -n "$OTHER_GID" ]; then
     IFS=',' read -ra OTHER_GID_ARRAY  <<< "$OTHER_GID"
     IFS=',' read -ra OTHER_RUN_GROUP_ARRAY  <<< "$OTHER_RUN_GROUP"
     length=${#OTHER_GID_ARRAY[@]}
-    GROUPS="--groups "
+    groups="--groups "
     for (( i=0; i<$length; i++ )); do
         getent group ${OTHER_RUN_GROUP_ARRAY[i]} &> /dev/null || groupadd --gid ${OTHER_GID_ARRAY[i]} ${OTHER_RUN_GROUP_ARRAY[i]}
-        GROUPS+="${OTHER_GID_ARRAY[i]},"
+        groups+="${OTHER_GID_ARRAY[i]},"
     done
-    otherGIDoption=${GROUPS::-1}
+    otherGIDoption=${groups::-1}
 fi
 
 if [ -n "$UID" ]; then


### PR DESCRIPTION
Hello @abretaud @mboudet !

For the beauris pipeline to work with our storage infrastructure at ABiMS, we need to add a supplementary group for the `RUN_USER`. Indeed each project space needs a specific posix group. The beauris `RUN_USER` needs one group to write outputs to the beauris dedicated project space, and another one to access the data stored in another project space. We currently have `Permission denied` when accessing the data :/

This did not come up earlier because we used only data from a project space owned by the `RUN_USER`.

Cheers,
Loraine

